### PR TITLE
recompute initial_cell_size and initial_Ucell_size when filtering cells

### DIFF
--- a/velocyto/analysis.py
+++ b/velocyto/analysis.py
@@ -162,6 +162,8 @@ class VelocytoLoom:
         """
         self.S, self.U, self.A = (X[:, bool_array] for X in (self.S, self.U, self.A))
         self.ca = {k: v[bool_array] for k, v in self.ca.items()}
+        self.initial_cell_size = self.S.sum(0)
+        self.initial_Ucell_size = self.U.sum(0)
         try:
             self.cluster_labels = self.cluster_labels[bool_array]  # type: np.ndarray
         except AttributeError:


### PR DESCRIPTION
Shape of initial_cell_size and initial_Ucell_size is incorrect after filtering cells