### PR TITLE
Mismatch between cells in column_attributes and count matrix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
                       'loompy',
                       'pysam',
                       'Click',
-                      'pandas'],
+                      'pandas>=0.24'],
     # command
     entry_points='''
         [console_scripts]

--- a/velocyto/commands/_run.py
+++ b/velocyto/commands/_run.py
@@ -283,9 +283,9 @@ def _run(*, bamfile: Tuple[str], gtffile: str,
 
     logging.debug("Writing loom file")
     try:
-        ds = loompy.create(filename=outfile, matrix=total, row_attrs=ra, col_attrs=ca, dtype="float32")
+        ds = loompy.create(filename=outfile, layers=total, row_attrs=ra, col_attrs=ca, dtype="float32")
         for layer_name in logic_obj.layers:
-            ds.set_layer(name=layer_name, matrix=layers[layer_name], dtype=loom_numeric_dtype)
+            ds.set_layer(name=layer_name, layers=layers[layer_name], dtype=loom_numeric_dtype)
         ds.attrs["velocyto.__version__"] = vcy.__version__
         ds.attrs["velocyto.logic"] = logic
         ds.close()

--- a/velocyto/commands/_run.py
+++ b/velocyto/commands/_run.py
@@ -30,7 +30,8 @@ def _run(*, bamfile: Tuple[str], gtffile: str,
          repmask: str, onefilepercell: bool, logic: str,
          without_umi: str, umi_extension: str, multimap: bool, test: bool,
          samtools_threads: int, samtools_memory: int, loom_numeric_dtype: str, dump: bool, verbose: int,
-         additional_ca: dict={}) -> None:
+         additional_ca: dict={},
+         **kwargs) -> None:
     """Runs the velocity analysis outputing a loom file
 
     BAMFILE or [BAMFILES] one or several bam files with position-sorted
@@ -244,8 +245,8 @@ def _run(*, bamfile: Tuple[str], gtffile: str,
     
     # If this data is from a 10X run, it is possible that additional_ca has data from cells that are present in the TSNE and Cluster files 
     # but not present in the count matrix.   these are not removed prior to attempting to create the loom file, this whole process will fail
-    if len(cell_bcs_order) < len(additional_ca['_X']):
-        tsne_file = os.path.join(samplefolder, "outs", "analysis", "tsne", "2_components", "projection.csv")
+    if (len(cell_bcs_order) < len(additional_ca['_X']) and kwargs['is_10X'] is True):
+        tsne_file = os.path.join(kwargs['samplefolder'], "outs", "analysis", "tsne", "2_components", "projection.csv")
         if os.path.exists(tsne_file):
             tsne_pd = pd.read_csv(tsne_file)
             tsne_pd["Barcode"] = [_[:-2] for _ in tsne_pd["Barcode"]]
@@ -253,7 +254,7 @@ def _run(*, bamfile: Tuple[str], gtffile: str,
             additional_ca['_X'] = tsne_pd['TSNE-1'].to_numpy()
             additional_ca['_Y'] = tsne_pd['TSNE-1'].to_numpy()
         
-        clusters_file = os.path.join(samplefolder, "outs", "analysis", "clustering", "graphclust", "clusters.csv")
+        clusters_file = os.path.join(kwargs['samplefolder'], "outs", "analysis", "clustering", "graphclust", "clusters.csv")
         if os.path.exists(clusters_file):
             labels = np.loadtxt(clusters_file, usecols=(1, ), delimiter=',', skiprows=1)
             clusters_pd = pd.read_csv(clusters_file)

--- a/velocyto/commands/run10x.py
+++ b/velocyto/commands/run10x.py
@@ -113,4 +113,4 @@ def run10x(samplefolder: str, gtffile: str,
                 sampleid=sampleid, metadatatable=metadatatable, repmask=mask, onefilepercell=False,
                 logic=logic, without_umi=False, umi_extension="no", multimap=multimap, test=False, samtools_threads=samtools_threads,
                 samtools_memory=samtools_memory, dump=dump, loom_numeric_dtype=dtype, verbose=verbose, additional_ca=additional_ca, 
-                is_10X=TRUE, samplefolder=samplefolder)
+                is_10X=True, samplefolder=samplefolder)

--- a/velocyto/commands/run10x.py
+++ b/velocyto/commands/run10x.py
@@ -112,4 +112,5 @@ def run10x(samplefolder: str, gtffile: str,
     return _run(bamfile=(bamfile, ), gtffile=gtffile, bcfile=bcfile, outputfolder=outputfolder,
                 sampleid=sampleid, metadatatable=metadatatable, repmask=mask, onefilepercell=False,
                 logic=logic, without_umi=False, umi_extension="no", multimap=multimap, test=False, samtools_threads=samtools_threads,
-                samtools_memory=samtools_memory, dump=dump, loom_numeric_dtype=dtype, verbose=verbose, additional_ca=additional_ca)
+                samtools_memory=samtools_memory, dump=dump, loom_numeric_dtype=dtype, verbose=verbose, additional_ca=additional_ca, 
+                is_10X=TRUE, samplefolder=samplefolder)


### PR DESCRIPTION
`run10X()` reads in the CellRanger computed tSNE and k-means cluster data and passes it to `_run()` as column attributes; however, the cells present in those datasets may differ from those in the eventual count matrix that `_run()` generates.  This causes an error with `loompy.create()` because there is a mismatch between  `ca['_X'].shape` and data in `tmp_layers`.  I've changed it so that `run10X()` passes two keyword arguments: `is_10X` and `samplefolder` so that for 10X runs, `_run()` will check to see if there is a difference in the number of cells in `additional_ca` and the count matrix barcodes and, if so, filter out the data for the removed cells.

Also, I've added a check for last bit of code to see what version of loompy is being used and uses the proper arguments for `loompy.create()` instead of using a `try/except` block.