### PR TITLE
Do not resolve paths for bamfile and barcodes:

### DIFF
--- a/velocyto/commands/run.py
+++ b/velocyto/commands/run.py
@@ -24,7 +24,7 @@ def id_generator(size: int=6, chars: str=string.ascii_uppercase + string.digits)
                                 file_okay=True,
                                 dir_okay=False,
                                 readable=True,
-                                resolve_path=True))
+                                resolve_path=False))
 @click.argument("gtffile",
                 type=click.Path(exists=True,
                                 file_okay=True,
@@ -36,7 +36,7 @@ def id_generator(size: int=6, chars: str=string.ascii_uppercase + string.digits)
               Cell barcodes should be specified in the bcfile as the `CB` tag for each read""",
               default=None,
               show_default=True,
-              type=click.Path(resolve_path=True,
+              type=click.Path(resolve_path=False,
                               file_okay=True,
                               dir_okay=False,
                               readable=True))


### PR DESCRIPTION
In nextflow files are staged with soft links in a working directory.

If you follow soft links you end up searching for cellsorted_ file in the input directory not in the working directory.

Consider this small example:

```
lrwxrwxrwx 1 davide.rambaldi sottoriva   36 May  8 16:41 barcodes.tsv.gz -> ../testdata/Sample_X/barcodes.tsv.gz
-rw-r--r-- 1 davide.rambaldi sottoriva 7.0M May  8 16:56 cellsorted_possorted_genome_bam.bam
lrwxrwxrwx 1 davide.rambaldi sottoriva   45 May  8 16:41 possorted_genome_bam.bam -> ../testdata/Sample_X/possorted_genome_bam.bam
lrwxrwxrwx 1 davide.rambaldi sottoriva   49 May  8 16:41 possorted_genome_bam.bam.bai -> ../testdata/Sample_X/possorted_genome_bam.bam.bai
-rw-r--r-- 1 davide.rambaldi sottoriva 1.2M May  8 16:56 Sample_X_T1.loom
```

If you resolve paths in this directory (an example working dir from nextflow with soft links) you end up creating ellsorted_possorted_genome_bam.bam file outside the working directoru in the original input dir and the pipeline, that looks for a cellsorted file in the working dir, will fail.

Best Regards.

Davide Rambaldi (Human Technopole)

With this fix we are able to call velocyto in a nextflow pipeline